### PR TITLE
chore(workspace): add nokkvi-ipc workspace member

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,6 +3092,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "nokkvi-ipc"
+version = "0.1.0"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "data"]
+members = [".", "data", "nokkvi-ipc"]
 
 [workspace.package]
 repository = "https://github.com/f-o-o-g-s/nokkvi"

--- a/nokkvi-ipc/Cargo.toml
+++ b/nokkvi-ipc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "nokkvi-ipc"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+# Structural invariant per nokkvi-new-feats.md §14C: this crate is
+# iced-free. Do not add an iced dependency — it would break the
+# fork-before-iced startup-latency contract for the CLI client path.
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/nokkvi-ipc/src/lib.rs
+++ b/nokkvi-ipc/src/lib.rs
@@ -1,0 +1,9 @@
+//! IPC layer for nokkvi external control. See ~/nokkvi-new-feats.md §14.
+//!
+//! Structural invariant: this crate is iced-free. The fork-before-iced
+//! client path links it directly, before iced's runtime is constructed,
+//! so adding iced here would break startup latency (and the build).
+
+pub fn ping() -> &'static str {
+    "pong"
+}


### PR DESCRIPTION
## Summary
- Preflight commit per `~/nokkvi-new-feats.md` §14I — verifies the new workspace member compiles cleanly before Phase 0 protocol code lands.
- New crate is iced-free by structural invariant (§14C). Comment in `nokkvi-ipc/Cargo.toml` documents the rule.
- Single function exported: `pub fn ping() -> &'static str { "pong" }`. Real IPC code lands in the Phase 0 PR.

## Test plan
- [x] `cargo build` succeeds at workspace root
- [x] `cargo build -p nokkvi-ipc` succeeds
- [x] `cargo test -p nokkvi-ipc` succeeds (no tests yet)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo +nightly fmt --all -- --check` clean